### PR TITLE
improve the code by defining the urdf path in config instead of hard coded in env.py

### DIFF
--- a/sim/env.py
+++ b/sim/env.py
@@ -8,19 +8,19 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-def model_dir() -> Path:
-    return Path(os.environ.get("MODEL_DIR", "sim/resources/stompymini"))
+def model_dir(robotname: str) -> Path:
+    return Path(os.environ.get("MODEL_DIR", "sim/resources/" + robotname))
 
 
 def run_dir() -> Path:
     return Path(os.environ.get("RUN_DIR", "runs"))
 
 
-def robot_urdf_path(legs_only: bool = False) -> Path:
+def robot_urdf_path(robotname: str, legs_only: bool = False) -> Path:
     if legs_only:
-        robot_path = model_dir() / "robot_fixed.urdf"
+        robot_path = model_dir(robotname) / "robot_fixed.urdf"
     else:
-        robot_path = model_dir() / "robot_fixed.urdf"
+        robot_path = model_dir(robotname) / "robot_fixed.urdf"
 
     if not robot_path.exists():
         raise FileNotFoundError(f"URDF file not found: {robot_path}")
@@ -28,11 +28,11 @@ def robot_urdf_path(legs_only: bool = False) -> Path:
     return robot_path.resolve()
 
 
-def robot_mjcf_path(legs_only: bool = False) -> Path:
+def robot_mjcf_path(robotname: str, legs_only: bool = False) -> Path:
     if legs_only:
-        robot_path = model_dir() / "robot_fixed.xml"
+        robot_path = model_dir(robotname) / "robot_fixed.xml"
     else:
-        robot_path = model_dir() / "robot_fixed.xml"
+        robot_path = model_dir(robotname) / "robot_fixed.xml"
 
     if not robot_path.exists():
         raise FileNotFoundError(f"MJCF file not found: {robot_path}")

--- a/sim/envs/humanoids/dora_config.py
+++ b/sim/envs/humanoids/dora_config.py
@@ -34,9 +34,8 @@ class DoraCfg(LeggedRobotCfg):
         torque_limit = 0.85
 
     class asset(LeggedRobotCfg.asset):
-        file = str(robot_urdf_path())
-
         name = "dora"
+        file = str(robot_urdf_path(name))
 
         foot_name = "leg_ankle_roll_Link"
         knee_name = "leg_knee_Link"

--- a/sim/envs/humanoids/g1_config.py
+++ b/sim/envs/humanoids/g1_config.py
@@ -34,9 +34,8 @@ class G1Cfg(LeggedRobotCfg):
         torque_limit = 0.85
 
     class asset(LeggedRobotCfg.asset):
-        file = str(robot_urdf_path())
-
         name = "g1"
+        file = str(robot_urdf_path(name))
 
         foot_name = "ankle_roll"
         knee_name = "knee_link"

--- a/sim/envs/humanoids/h1_config.py
+++ b/sim/envs/humanoids/h1_config.py
@@ -36,9 +36,8 @@ class H1Cfg(LeggedRobotCfg):
         torque_limit = 0.85
 
     class asset(LeggedRobotCfg.asset):
-        file = str(robot_urdf_path())
-
-        name = "h1"
+        name = "h1_2"
+        file = str(robot_urdf_path(name))
 
         foot_name = "ankle_roll"
         knee_name = "knee_link"

--- a/sim/envs/humanoids/stompymini_config.py
+++ b/sim/envs/humanoids/stompymini_config.py
@@ -33,9 +33,9 @@ class MiniCfg(LeggedRobotCfg):
         torque_limit = 0.85
 
     class asset(LeggedRobotCfg.asset):
-        file = str(robot_urdf_path())
+        name = "stompymini"
+        file = str(robot_urdf_path(name))
 
-        name = "stompy"
 
         foot_name = ["RS_01_Stator", "RS_01_Stator_2"]
         knee_name = ["RS_04_Rotor_7", "RS_04_Rotor_8"]

--- a/sim/envs/humanoids/stompypro_config.py
+++ b/sim/envs/humanoids/stompypro_config.py
@@ -33,10 +33,9 @@ class StompyProCfg(LeggedRobotCfg):
         torque_limit = 0.85
 
     class asset(LeggedRobotCfg.asset):
-        file = str(robot_urdf_path())
-
         name = "stompypro"
-
+        file = str(robot_urdf_path(name))
+        
         foot_name = ["L_foot", "R_foot"]
         knee_name = ["L_calf", "R_calf"]
 

--- a/sim/envs/humanoids/xbot_config.py
+++ b/sim/envs/humanoids/xbot_config.py
@@ -33,9 +33,9 @@ class XBotCfg(LeggedRobotCfg):
         torque_limit = 0.85
 
     class asset(LeggedRobotCfg.asset):
-        file = str(robot_urdf_path())
-
         name = "xbot"
+        file = str(robot_urdf_path(name))
+
 
         foot_name = "ankle_roll"
         knee_name = "knee"


### PR DESCRIPTION
When I run stompypro i encountered error telling me that a joint name is not found. Later realized that the urdf path is hard-coded with stompymini. Therefore modified so that the name of robot can be defined in each config file and the urdf is loaded corresponding to the name of the robot