### PR TITLE
fix : termination fix for all the environments that inherit legged ro…

### DIFF
--- a/sim/envs/base/legged_robot.py
+++ b/sim/envs/base/legged_robot.py
@@ -685,6 +685,9 @@ class LeggedRobot(BaseTask):
         termination_contact_names = []
         for name in self.cfg.asset.terminate_after_contacts_on:
             termination_contact_names.extend([s for s in body_names if name in s])
+        safety_termination_contact_names = []
+        for name in self.cfg.safety.terminate_after_contacts_on:
+            safety_termination_contact_names.extend([s for s in body_names if name in s])
         base_init_state_list = (
             self.cfg.init_state.pos
             + self.cfg.init_state.rot
@@ -757,6 +760,14 @@ class LeggedRobot(BaseTask):
         for i in range(len(termination_contact_names)):
             self.termination_contact_indices[i] = self.gym.find_actor_rigid_body_handle(
                 self.envs[0], self.actor_handles[0], termination_contact_names[i]
+            )
+
+        self.safety_termination_contact_indices = torch.zeros(
+            len(safety_termination_contact_names), dtype=torch.long, device=self.device, requires_grad=False
+        )
+        for i in range(len(safety_termination_contact_names)):
+            self.safety_termination_contact_indices[i] = self.gym.find_actor_rigid_body_handle(
+                self.envs[0], self.actor_handles[0], safety_termination_contact_names[i]
             )
 
     def _get_env_origins(self):

--- a/sim/envs/base/legged_robot_config.py
+++ b/sim/envs/base/legged_robot_config.py
@@ -114,6 +114,11 @@ class LeggedRobotCfg(BaseConfig):
         # decimation: Number of control action updates @ sim DT per policy DT
         decimation = 4
 
+    class safety:
+        # safety factors
+        termination_height = 0.0
+        terminate_after_contacts_on = []
+
     class asset:
         file = ""
         name = "legged_robot"  # actor name

--- a/sim/envs/humanoids/stompypro_config.py
+++ b/sim/envs/humanoids/stompypro_config.py
@@ -31,11 +31,30 @@ class StompyProCfg(LeggedRobotCfg):
         pos_limit = 1.0
         vel_limit = 1.0
         torque_limit = 0.85
+        termination_height = 0.1
+        terminate_after_contacts_on = [
+            "base",
+            "trunk",
+            "L_buttock",
+            "L_leg",
+            "L_thigh",
+            "L_calf",
+            "L_clav",
+            "L_scapula",
+            "L_uarm",
+            "L_farm",
+            "R_buttock",
+            "R_leg",
+            "R_thigh",
+            "R_calf",
+            "R_clav",
+            "R_scapula",
+        ]
 
     class asset(LeggedRobotCfg.asset):
         name = "stompypro"
         file = str(robot_urdf_path(name))
-        
+
         foot_name = ["L_foot", "R_foot"]
         knee_name = ["L_calf", "R_calf"]
 

--- a/sim/envs/humanoids/stompypro_env.py
+++ b/sim/envs/humanoids/stompypro_env.py
@@ -108,6 +108,9 @@ class StompyProFreeEnv(LeggedRobot):
             torch.norm(self.contact_forces[:, self.termination_contact_indices, :], dim=-1) > 1.0,
             dim=1,
         )
+        self.reset_buf |= torch.any(
+            self.rigid_state[:, self.safety_termination_contact_indices, 2] < self.cfg.safety.termination_height, dim=1
+        )
         self.reset_buf |= self.root_states[:, 2] < self.cfg.asset.termination_height
         self.time_out_buf = self.episode_length_buf > self.max_episode_length  # no terminal reward for time-outs
         self.reset_buf |= self.time_out_buf

--- a/sim/resources/stompypro/robot_fixed.urdf
+++ b/sim/resources/stompypro/robot_fixed.urdf
@@ -6,7 +6,7 @@
       <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001" />
       </inertial>
     </link>
-  <joint name="floating_base" type="fixed">
+  <joint name="floating_base" type="fixed" dont_collapse="true">
     <origin rpy="0 0 0" xyz="0 0 0.0" />
     <parent link="base" />
     <child link="trunk" />
@@ -292,7 +292,7 @@
         </geometry>
       </collision>
     </link>
-  <joint name="L_shoulder_y" type="fixed">
+  <joint name="L_shoulder_y" type="fixed" dont_collapse="true">
     <origin rpy="0 0 0" xyz="0 0.255 0.45" />
     <parent link="trunk" />
     <child link="L_clav" />
@@ -319,7 +319,7 @@
         </geometry>
       </collision>
     </link>
-  <joint name="L_shoulder_x" type="fixed">
+  <joint name="L_shoulder_x" type="fixed" dont_collapse="true">
     <origin rpy="0.0 0.0 0.0" xyz="0 0 0" />
     <parent link="L_clav" />
     <child link="L_scapula" />
@@ -344,7 +344,7 @@
         </geometry>
       </collision>
     </link>
-  <joint name="L_shoulder_z" type="fixed">
+  <joint name="L_shoulder_z" type="fixed" dont_collapse="true">
     <origin rpy="0.0 0.0 0.0" xyz="0 0 0" />
     <parent link="L_scapula" />
     <child link="L_uarm" />
@@ -369,7 +369,7 @@
         </geometry>
       </collision>
     </link>
-  <joint name="L_elbow_x" type="fixed">
+  <joint name="L_elbow_x" type="fixed" dont_collapse="true">
     <origin rpy="0.0 0.0 0.0" xyz="0 0 -0.23" />
     <parent link="L_uarm" />
     <child link="L_farm" />
@@ -394,7 +394,7 @@
         </geometry>
       </collision>
     </link>
-  <joint name="R_shoulder_y" type="fixed">
+  <joint name="R_shoulder_y" type="fixed" dont_collapse="true">
     <origin rpy="0 0 0" xyz="0 -0.255 0.45" />
     <parent link="trunk" />
     <child link="R_clav" />
@@ -421,7 +421,7 @@
         </geometry>
       </collision>
     </link>
-  <joint name="R_shoulder_x" type="fixed">
+  <joint name="R_shoulder_x" type="fixed" dont_collapse="true">
     <origin rpy="0.0 0.0 0.0" xyz="0 0 0" />
     <parent link="R_clav" />
     <child link="R_scapula" />
@@ -446,7 +446,7 @@
         </geometry>
       </collision>
     </link>
-  <joint name="R_shoulder_z" type="fixed">
+  <joint name="R_shoulder_z" type="fixed" dont_collapse="true">
     <origin rpy="0.0 0.0 0.0" xyz="0 0 0" />
     <parent link="R_scapula" />
     <child link="R_uarm" />
@@ -471,7 +471,7 @@
         </geometry>
       </collision>
     </link>
-  <joint name="R_elbow_x" type="fixed">
+  <joint name="R_elbow_x" type="fixed" dont_collapse="true">
     <origin rpy="0.0 0.0 0.0" xyz="0 0 -0.23" />
     <parent link="R_uarm" />
     <child link="R_farm" />


### PR DESCRIPTION
* Used rigid_states() to extract position and orientation of rigid bodies linked to joints (e.g., "L_knee").
* Ensures accurate position retrieval to safely terminate episodes based on joint state.
* Ran ```make format && make static-checks```. The change doesn't seem to harm the existing formatting.