### PR TITLE
fix typo on save path print statement

### DIFF
--- a/sim/sim2sim.py
+++ b/sim/sim2sim.py
@@ -336,7 +336,7 @@ def run_mujoco(
     print(f"Average speed: {average_speed:.4f} m/s")
 
     if args.log_h5:
-        print("Saving data to " + os.path.abspath(f"data{now}.h5"))
+        print(f"Saving data to {os.path.abspath(f'{embodiment}/{now}.h5')}")
         h5_file.close()
 
 def parse_modelmeta(


### PR DESCRIPTION
Simple change to fix typo

Current code prints 

Saving data to /home/kasm-user/sim/data2024-11-05_01-23-37.h5

But the file is actually saved to 

/home/kasm-user/sim/stompypro/2024-11-05_01-23-37.h5

So I modified the print statement to match.